### PR TITLE
Add support for screen edges as hot areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,16 @@ command = "lock"  # required
 # Options: top_left, top_right, bottom_right, and bottom_left.
 locations = ["bottom_right", "bottom_left"]  # default
 
-# Size of the hot corners in pixels.
+# Alternatively, you can specify an edge.
+# Options: left, right, top, bottom
+# locations = ["top", "bottom"]
+
+# Size of the hot corners in pixels. Size can be either one "size" value,
+# or separate "size_height" and "size_width" values. Use one or the other.
 size = 10  # default
+# size_height = 10
+# size_width = 10
+
 
 # Timeout in milliseconds before command is triggered.
 timeout_ms = 250  # default

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ fn default_locations() -> Vec<Location> {
     vec![Location::BottomRight, Location::BottomLeft]
 }
 
-fn default_size() -> u8 {
+fn default_size() -> u16 {
     10
 }
 
@@ -22,7 +22,11 @@ pub struct CornerConfig {
     #[serde(default = "default_locations")]
     pub locations: Vec<Location>,
     #[serde(default = "default_size")]
-    pub size: u8,
+    pub size: u16,
+    #[serde(default = "default_size")]
+    pub size_width: u16,
+    #[serde(default = "default_size")]
+    pub size_height: u16,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u16,
 }
@@ -39,6 +43,10 @@ pub enum Location {
     TopRight,
     BottomRight,
     BottomLeft,
+    Left,
+    Right,
+    Top,
+    Bottom,
 }
 
 type Config = HashMap<String, CornerConfig>;

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -235,6 +235,10 @@ impl Wayland {
                 Location::TopRight => Anchor::Top | Anchor::Right,
                 Location::BottomRight => Anchor::Bottom | Anchor::Right,
                 Location::BottomLeft => Anchor::Bottom | Anchor::Left,
+                Location::Left => Anchor::Left,
+                Location::Right => Anchor::Right,
+                Location::Top => Anchor::Top,
+                Location::Bottom => Anchor::Bottom,
             })
             .map(|anchor| {
                 info!("Adding anchorpoint {:?}", anchor);
@@ -246,8 +250,22 @@ impl Wayland {
                     zwlr_layer_shell_v1::Layer::Top,
                     "waycorner".to_owned(),
                 );
-                let size = corner_config.size.into();
-                layer_surface.set_size(size, size);
+                
+                let size_width = 
+                	if corner_config.size_width != 10 {
+                		corner_config.size_width.into()
+                	} else {
+                		corner_config.size.into()
+                	};
+                
+                let size_height =
+                	if corner_config.size_height != 10 {
+                		corner_config.size_height.into()
+                	} else {
+                		corner_config.size.into()
+                	};
+                
+                layer_surface.set_size(size_width, size_height);
                 layer_surface.set_anchor(anchor);
                 // Ignore exclusive zones.
                 layer_surface.set_exclusive_zone(-1);
@@ -297,7 +315,7 @@ impl Wayland {
                         0,
                         width.try_into().unwrap(),
                         height.try_into().unwrap(),
-                        (4 * height).try_into().unwrap(),
+                        (4 * width).try_into().unwrap(),
                         Format::Argb8888,
                     );
                     surface_handle.attach(Some(&buffer), 0, 0);


### PR DESCRIPTION
Adds support for screen edges as hot areas, as discussed in #1. Had to add some other changes to support specifying height and width as well, but any current configs should still work as they did before (you can specify either size for a square or size_height and size_width for a rectangle).