### PR TITLE
Make separate enter_command and exit_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Default configuration location is `~/.config/waycorner/config.toml`, this needs 
 
 ```toml
 [left]
-# Shell command to execute when hotcorner is triggered.
+# Shell commands to execute when hotcorner is triggered,
+# at least one is required.
+
 enter_command = [ "notify-send", "enter" ]
 exit_command = [ "notify-send", "exit" ]
 # Omit enter_command or exit command to run nothing when

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Default configuration location is `~/.config/waycorner/config.toml`, this needs 
 ```toml
 [left]
 # Shell command to execute when hotcorner is triggered.
-command = "lock"  # required
+enter_command = [ "notify-send", "enter" ]
+exit_command = [ "notify-send", "exit" ]
+# Omit enter_command or exit command to run nothing when
+# entering/exiting the corner
 
 # Locations of the hot corners.
 # Options: top_left, top_right, bottom_right, and bottom_left.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Default configuration location is `~/.config/waycorner/config.toml`, this needs 
 # Shell commands to execute when hotcorner is triggered,
 # at least one is required.
 
+# Command to run when cursor enters hotcorner.
+# `command` is an alias for `enter_command`.
 enter_command = [ "notify-send", "enter" ]
+# Command to run when cursor exits hotcorner.
 exit_command = [ "notify-send", "exit" ]
-# Omit enter_command or exit command to run nothing when
-# entering/exiting the corner
 
 # Locations of the hot corners.
 # Options: top_left, top_right, bottom_right, and bottom_left.

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,13 +72,12 @@ pub fn get_configs(config_path: PathBuf) -> Result<Vec<CornerConfig>> {
     toml::from_str::<Config>(config_content.as_str()).map(|item| {
         item.into_iter()
             .map(|(key, value)| {
-                if key.ends_with(".output") || value.enter_command.len() != 0 || value.exit_command.len() != 0 {
-                    Ok(value)
-                } else {
-                    Err(Error::msg(format!(
-                        "You must provide either an `exit_command` or an `enter_command` for key `{}`",
-                        key
-                    )))
+                if value.enter_command.is_empty() && value.exit_command.is_empty() {
+                    bail!(
+                        "You must provide either an `exit_command` or an `enter_command` for `{key}`",
+                    )
+                }
+                Ok(value)
                 }
             })
             .collect::<Result<Vec<_>>>()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, env, fs::File, io::Read, path::PathBuf};
 
-use anyhow::{Context, Error, Result};
+use anyhow::{Context, Error, Result, bail};
 use serde::Deserialize;
 
 fn default_locations() -> Vec<Location> {
@@ -74,11 +74,11 @@ pub fn get_configs(config_path: PathBuf) -> Result<Vec<CornerConfig>> {
             .map(|(key, value)| {
                 if value.enter_command.is_empty() && value.exit_command.is_empty() {
                     bail!(
-                        "You must provide either an `exit_command` or an `enter_command` for `{key}`",
+                        "You must provide either an `exit_command` or an `enter_command` for `{}`",
+                        key
                     )
                 }
                 Ok(value)
-                }
             })
             .collect::<Result<Vec<_>>>()
             .map_err(|error| -> Error { error.into() })

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ fn default_command() -> Vec<String> {
 #[derive(Clone, Debug, Deserialize)]
 pub struct CornerConfig {
     pub output: Option<OutputConfig>,
-    #[serde(default = "default_command")]
+    #[serde(default = "default_command", alias = "command"]
     pub enter_command: Vec<String>,
     #[serde(default = "default_command")]
     pub exit_command: Vec<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,10 +15,17 @@ fn default_timeout_ms() -> u16 {
     250
 }
 
+fn default_command() -> Vec<String> {
+    Vec::new()
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct CornerConfig {
     pub output: Option<OutputConfig>,
-    pub command: Vec<String>,
+    #[serde(default = "default_command")]
+    pub enter_command: Vec<String>,
+    #[serde(default = "default_command")]
+    pub exit_command: Vec<String>,
     #[serde(default = "default_locations")]
     pub locations: Vec<Location>,
     #[serde(default = "default_size")]

--- a/src/corner.rs
+++ b/src/corner.rs
@@ -66,7 +66,7 @@ impl Corner {
                     if let Some(event) = last_event {
                         if event == CornerEvent::Enter {
                             self.execute_enter_command()?;
-                        } else if value == CornerEvent::Leave {
+                        } else if event == CornerEvent::Leave {
                             self.execute_exit_command()?;
                         }
                         command_done_at = Some(Instant::now());

--- a/src/corner.rs
+++ b/src/corner.rs
@@ -63,16 +63,12 @@ impl Corner {
                     }
                 }
                 Err(_error) => {
-                    if last_event.map_or(Ok(false), |value| -> Result<bool> {
-                        if value == CornerEvent::Enter {
+                    if let Some(event) = last_event {
+                        if event == CornerEvent::Enter {
                             self.execute_enter_command()?;
                         } else if value == CornerEvent::Leave {
                             self.execute_exit_command()?;
-                        } else {
-                            return Ok(false);
                         }
-                        return Ok(true);
-                    })? {
                         command_done_at = Some(Instant::now());
                     }
                     last_event = None;

--- a/src/corner.rs
+++ b/src/corner.rs
@@ -65,9 +65,9 @@ impl Corner {
                 Err(_error) => {
                     if let Some(event) = last_event {
                         if event == CornerEvent::Enter {
-                            self.execute_enter_command()?;
+                            self.execute_command(&self.config.enter_command)?;
                         } else if event == CornerEvent::Leave {
-                            self.execute_exit_command()?;
+                            self.execute_command(&self.config.exit_command)?;
                         }
                         command_done_at = Some(Instant::now());
                     }
@@ -106,29 +106,9 @@ impl Corner {
             .unwrap_or(true)
     }
 
-    fn execute_enter_command(&self) -> Result<()> {
-        if let Some(binary) = self.config.enter_command.first() {
-            let args = self
-                .config
-                .enter_command
-                .iter()
-                .enumerate()
-                .filter(|(index, _)| index > 0.borrow())
-                .map(|(_, value)| value)
-                .collect::<Vec<_>>();
-            info!("executing command: {} {:?}", binary, args);
-            let output = Command::new(binary).args(args).output()?;
-            info!("output received: {:?}", output);
-        }
-
-        Ok(())
-    }
-
-    fn execute_exit_command(&self) -> Result<()> {
-        if let Some(binary) = self.config.exit_command.first() {
-            let args = self
-                .config
-                .exit_command
+    fn execute_command(&self, command: &Vec<String>) -> Result<()> {
+        if let Some(binary) = command.first() {
+            let args = command
                 .iter()
                 .enumerate()
                 .filter(|(index, _)| index > 0.borrow())


### PR DESCRIPTION
- Add an enter_command parameter to config.toml with the same behavior
  as the previous command parameter
- Add an exit_command parameter to config.toml which will be triggered
  when leaving the hot corner
- Stop enter_command and exit_command from being required (in-case
  someone only wants one of them)
- Update the README to reflect this change
- This pull request resolves #4

~~BREAKING CHANGE: This commit *removes* the command parameter from
config.toml~~