### PR TITLE
Add the possibility to order corners by giving each of them a priority 

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ size = 10  # default
 # Timeout in milliseconds before command is triggered.
 timeout_ms = 250  # default
 
+# Priority when drawing the corner (higher priority on top)
+priority = 0  # default                                                              
+
 # Optional output config to specify what output to use.
 [left.output]
 # Regex to match output descriptions on.


### PR DESCRIPTION
A priority value can be set for each hot corner. Corners with higher priority are draw last (on top).

This solves #8 for me: I define two corners, one with the enter command, the other with the exit command, and give them two different timeout times. For this to work I need the corner with the enter command to be smaller than the other, therefore it has to be consistently on top of the other.