### PR TITLE
Choose color of corners in preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Added support for changing the preview color.
+
+### Changed
 - Update Wayland dependencies to fix coredump.
 - Updated compatible dependencies.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ size = 10  # default
 # Timeout in milliseconds before command is triggered.
 timeout_ms = 250  # default
 
+# Color of the corner when previewed
+# (useful for debuging purposes when setting up several hot corners)
+color = red  # default
+
 # Optional output config to specify what output to use.
 [left.output]
 # Regex to match output descriptions on.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ size = 10  # default
 # Timeout in milliseconds before command is triggered.
 timeout_ms = 250  # default
 
-# Color of the corner when previewed
-# (useful for debuging purposes when setting up several hot corners)
-color = red  # default
+# Hex color of the corner when previewed, supports transparency. (#AARRGGBB or #RRGGBB)
+# (Useful for debuging purposes when setting up several hot corners.)
+color = #FFFF0000  # default
 
 # Optional output config to specify what output to use.
 [left.output]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,14 @@
 use std::{collections::HashMap, env, fs::File, io::Read, path::PathBuf};
 
-use anyhow::{Context, Error, Result, bail};
-use serde::Deserialize;
+use anyhow::{bail, Context, Error, Result};
+use regex::Regex;
+use serde::{
+    de::{self, Unexpected},
+    Deserialize, Deserializer,
+};
+
+pub const COLOR_TRANSPARENT: u32 = 0x00_00_00_00;
+pub const COLOR_RED: u32 = 0xFF_FF_00_00;
 
 fn default_locations() -> Vec<Location> {
     vec![Location::BottomRight, Location::BottomLeft]
@@ -15,12 +22,37 @@ fn default_timeout_ms() -> u16 {
     250
 }
 
-fn default_color() -> String {
-    "red".to_string()
+fn default_color() -> u32 {
+    COLOR_RED
 }
 
 fn default_command() -> Vec<String> {
     Vec::new()
+}
+
+fn from_hex<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: &str = Deserialize::deserialize(deserializer)?;
+    let re: Regex = Regex::new(r"^#[0-9a-fA-F]{6,8}$").unwrap();
+
+    if !re.is_match(value) {
+        return Err(de::Error::invalid_value(
+            Unexpected::Str(value),
+            &"a valid hex code",
+        ));
+    }
+    let without_prefix = value.trim_start_matches("#");
+    u32::from_str_radix(without_prefix, 16)
+        .map(|val| {
+            if val <= 0xFF_FF_FF {
+                val | 0xFF_00_00_00
+            } else {
+                val
+            }
+        })
+        .map_err(de::Error::custom)
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -36,8 +68,8 @@ pub struct CornerConfig {
     pub size: u8,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u16,
-    #[serde(default = "default_color")]
-    pub color: String,
+    #[serde(default = "default_color", deserialize_with = "from_hex")]
+    pub color: u32,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -63,7 +95,13 @@ pub fn get_configs(config_path: PathBuf) -> Result<Vec<CornerConfig>> {
             .expect("could not find the $HOME env var to use for the default config path");
         let relative_path = config_path
             .to_str()
-            .expect(format!("invalid config path specified: {}", config_path.display()).as_str())
+            .expect(
+                format!(
+                    "invalid config path specified: {}",
+                    config_path.display()
+                )
+                .as_str(),
+            )
             .to_string()
             .split_off(2);
         PathBuf::from(home_path).join(relative_path)
@@ -71,8 +109,9 @@ pub fn get_configs(config_path: PathBuf) -> Result<Vec<CornerConfig>> {
         config_path
     };
     info!("Using config: {}", path.display());
-    let mut config_file = File::open(path.clone())
-        .with_context(|| format!("could not open the file {}", path.display()))?;
+    let mut config_file = File::open(path.clone()).with_context(|| {
+        format!("could not open the file {}", path.display())
+    })?;
     let mut config_content = String::new();
     config_file.read_to_string(&mut config_content)?;
     toml::from_str::<Config>(config_content.as_str()).map(|item| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,10 @@ fn default_timeout_ms() -> u16 {
     250
 }
 
+fn default_color() -> String {
+    "red".to_string()
+}
+
 fn default_command() -> Vec<String> {
     Vec::new()
 }
@@ -32,6 +36,8 @@ pub struct CornerConfig {
     pub size: u8,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u16,
+    #[serde(default = "default_color")]
+    pub color: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -23,6 +23,8 @@ use std::{
     },
 };
 
+use regex::Regex;
+
 use wayland_client::{
     protocol::{wl_output::WlOutput, wl_pointer, wl_surface::WlSurface},
     Attached, Display, Main, Proxy,
@@ -66,8 +68,18 @@ impl Color {
             "red" => Color::RED,
             "green" => Color::GREEN,
             "blue" => Color::BLUE,
-            _ => Color::RED,
+            _ => Color::from_hexcode(preview_color),
         }
+    }
+
+    pub fn from_hexcode(hexcode: &str) -> u32 {
+        let re: Regex = Regex::new(r"^#[0-9a-fA-F]{6}$").unwrap();
+
+        if ! re.is_match(hexcode) {
+            panic!("Hexcode is not valid.");
+        }
+        let without_prefix = hexcode.trim_start_matches("#");
+        0xD0_00_00_00 + u32::from_str_radix(without_prefix, 16).unwrap()
     }
 }
 

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -52,11 +52,30 @@ pub struct Wayland {
     corner_to_surfaces: Vec<(Corner, Vec<WlSurface>)>,
 }
 
-const RED: u32 = 0xD0_FF_00_00;
-const TRANSPARENT: u32 = 0x00_00_00_00;
+#[non_exhaustive]
+struct Color;
+
+impl Color {
+    pub const TRANSPARENT: u32 = 0x00_00_00_00;
+    pub const RED: u32 = 0xD0_FF_00_00;
+    pub const GREEN: u32 = 0xD0_00_FF_00;
+    pub const BLUE: u32 = 0xD0_00_00_FF;
+
+    pub fn get(preview_color: &str) -> u32 {
+        match preview_color {
+            "red" => Color::RED,
+            "green" => Color::GREEN,
+            "blue" => Color::BLUE,
+            _ => Color::RED,
+        }
+    }
+}
 
 impl Wayland {
-    pub fn new(configs: Vec<CornerConfig>, preview: bool) -> Self {
+    pub fn new(
+        configs: Vec<CornerConfig>,
+        preview: bool,
+    ) -> Self {
         Wayland {
             preview,
             corner_to_surfaces: configs
@@ -184,6 +203,7 @@ impl Wayland {
     ) -> Result<()> {
         info!("{:?}", info);
         let preview = self.preview;
+
         self.corner_to_surfaces
             .iter_mut()
             .map(|(corner, surfaces)| -> Result<()> {
@@ -207,6 +227,7 @@ impl Wayland {
                     &output,
                     corner.config.clone(),
                     preview,
+                    Color::get(corner.config.color.as_str()),
                 )?;
 
                 surfaces.append(&mut corner_surfaces);
@@ -226,6 +247,7 @@ impl Wayland {
         output: &WlOutput,
         corner_config: CornerConfig,
         preview: bool,
+        preview_color: u32,
     ) -> Result<Vec<WlSurface>> {
         corner_config
             .locations
@@ -252,7 +274,13 @@ impl Wayland {
                 // Ignore exclusive zones.
                 layer_surface.set_exclusive_zone(-1);
 
-                Wayland::initial_draw(environment, surface.clone(), layer_surface, preview)?;
+                Wayland::initial_draw(
+                    environment,
+                    surface.clone(),
+                    layer_surface,
+                    preview,
+                    preview_color,
+                )?;
 
                 Ok(surface)
             })
@@ -264,6 +292,7 @@ impl Wayland {
         surface: WlSurface,
         layer_surface: Main<ZwlrLayerSurfaceV1>,
         preview: bool,
+        preview_color: u32,
     ) -> Result<()> {
         let mut double_pool = environment
             .create_double_pool(|_| {})
@@ -286,7 +315,11 @@ impl Wayland {
                     pool.seek(SeekFrom::Start(0)).unwrap();
                     {
                         let mut writer = BufWriter::new(&mut *pool);
-                        let color = if preview { RED } else { TRANSPARENT };
+                        let color = if preview {
+                            preview_color
+                        } else {
+                            Color::TRANSPARENT
+                        };
                         for _ in 0..pxcount {
                             writer.write_all(&color.to_ne_bytes()).unwrap();
                         }


### PR DESCRIPTION
This lets the user specify a color for each corner in preview mode. Supported are the strings "red", "green", and "blue" and the any arbitrary color hexcode with the format "#XXXXXX".

Use case: I wanted to be able to specify different colors for each corner in preview mode for debugging purposes.