### PR TITLE
Add support for hot screen edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Added support for changing the preview color.
+- Added support for edges.
 
 ### Changed
 - Update Wayland dependencies to fix coredump.

--- a/README.md
+++ b/README.md
@@ -51,11 +51,14 @@ exit_command = [ "notify-send", "exit" ]
 # - for edges: top, bottom, right, left.
 locations = ["bottom_right", "bottom_left"]  # default
 
-# Size of the hot corners in pixels.
+# Size of the hot corners in pixels, for edges the size means the width
+# for vertical edges, and height for horizontal edges. The other dimension
+# will be the width/height of your display - the set margin.
 size = 10  # default
 
-# Margin on the sides of the hot edges (only for edges)
-# margin = 20  # default
+# Margin on the sides of the hot edges, only applicable to edge locations.
+# See the comment with sizes attribute above.
+margin = 20  # default
 
 # Timeout in milliseconds before command is triggered.
 timeout_ms = 250  # default

--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ enter_command = [ "notify-send", "enter" ]
 exit_command = [ "notify-send", "exit" ]
 
 # Locations of the hot corners.
-# Options: top_left, top_right, bottom_right, and bottom_left.
+# Options:
+# - for corners: top_left, top_right, bottom_right, and bottom_left;
+# - for edges: top, bottom, right, left.
 locations = ["bottom_right", "bottom_left"]  # default
 
 # Size of the hot corners in pixels.
 size = 10  # default
+
+# Margin on the sides of the hot edges (only for edges)
+# margin = 20  # default
 
 # Timeout in milliseconds before command is triggered.
 timeout_ms = 250  # default

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,10 @@ fn default_size() -> u8 {
     10
 }
 
+fn default_margin() -> i8 {
+    5
+}
+
 fn default_timeout_ms() -> u16 {
     250
 }
@@ -66,6 +70,8 @@ pub struct CornerConfig {
     pub locations: Vec<Location>,
     #[serde(default = "default_size")]
     pub size: u8,
+    #[serde(default = "default_margin")]
+    pub margin: i8,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u16,
     #[serde(default = "default_color", deserialize_with = "from_hex")]
@@ -84,6 +90,10 @@ pub enum Location {
     TopRight,
     BottomRight,
     BottomLeft,
+    Left,
+    Right,
+    Top,
+    Bottom,
 }
 
 type Config = HashMap<String, CornerConfig>;

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ fn default_size() -> u8 {
 }
 
 fn default_margin() -> i8 {
-    5
+    20
 }
 
 fn default_timeout_ms() -> u16 {

--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -239,14 +239,23 @@ impl Wayland {
             .locations
             .iter()
             .map(|location| {
-                match location {
+                let anchor = match location {
                     Location::TopLeft => Anchor::Top | Anchor::Left,
                     Location::TopRight => Anchor::Top | Anchor::Right,
                     Location::BottomRight => Anchor::Bottom | Anchor::Right,
                     Location::BottomLeft => Anchor::Bottom | Anchor::Left,
-                }
-            })
-            .map(|anchor| {
+                    Location::Left => {
+                        Anchor::Left | Anchor::Top | Anchor::Bottom
+                    }
+                    Location::Right => {
+                        Anchor::Right | Anchor::Top | Anchor::Bottom
+                    }
+                    Location::Top => Anchor::Top | Anchor::Left | Anchor::Right,
+                    Location::Bottom => {
+                        Anchor::Bottom | Anchor::Left | Anchor::Right
+                    }
+                };
+
                 info!("Adding anchorpoint {:?}", anchor);
                 let surface = environment.create_surface().detach();
 
@@ -257,7 +266,36 @@ impl Wayland {
                     "waycorner".to_owned(),
                 );
                 let size = corner_config.size.into();
-                layer_surface.set_size(size, size);
+                let margin = corner_config.margin.into();
+                layer_surface.set_size(
+                    match location {
+                        Location::Top | Location::Bottom => 0,
+                        _ => size,
+                    },
+                    match location {
+                        Location::Left | Location::Right => 0,
+                        _ => size,
+                    },
+                );
+                layer_surface.set_margin(
+                    // top, right, bottom, left
+                    match location {
+                        Location::Left | Location::Right => margin,
+                        _ => 0,
+                    },
+                    match location {
+                        Location::Top | Location::Bottom => margin,
+                        _ => 0,
+                    },
+                    match location {
+                        Location::Left | Location::Right => margin,
+                        _ => 0,
+                    },
+                    match location {
+                        Location::Top | Location::Bottom => margin,
+                        _ => 0,
+                    },
+                );
                 layer_surface.set_anchor(anchor);
                 // Ignore exclusive zones.
                 layer_surface.set_exclusive_zone(-1);
@@ -319,7 +357,7 @@ impl Wayland {
                             0,
                             width.try_into().unwrap(),
                             height.try_into().unwrap(),
-                            (4 * height).try_into().unwrap(),
+                            (4 * width).try_into().unwrap(),
                             Format::Argb8888,
                         );
                         surface_handle.attach(Some(&buffer), 0, 0);


### PR DESCRIPTION
My implementation of #1. It lets you choose a screen edge instead of a corner. Margins can be added to the sides of the edges to avoid conflict with other hot corners.