### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,16 @@ cargo install waycorner --locked
 
 ### Nix/NixOS
 
-[`waycorner` package]: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/misc/waycorner/default.nix
-[search.nixos.org]: https://search.nixos.org/packages?channel=unstable&show=waycorner&from=0&size=50&sort=relevance&type=packages&query=waycorner
+[`waycorner`]: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/misc/waycorner/default.nix
+[See installation instructions.]: https://search.nixos.org/packages?channel=unstable&show=waycorner&from=0&size=50&sort=relevance&type=packages&query=waycorner
 [@NotAShelf]: https://github.com/notashelf
 [out-of-date package report]: https://github.com/NixOS/nixpkgs/issues/new?assignees=&labels=9.needs%3A+package+%28update%29&projects=&template=out_of_date_package_report.md&title=Update+request%3A+PACKAGENAME+OLDVERSION+%E2%86%92+NEWVERSION
 
-There is a [waycorner package] package available via Nixpkgs. Refer to [search.nixos.org] page for Waycorner
-for the appropriate installation methods.
+The [`waycorner`] package is available via Nixpkgs. [See installation instructions.]
 
 > [!NOTE]
-> The Waycorner package in Nixpkgs is not updated automatically by the project author, and is instead
-> maintained by [@NotAShelf]. Please contact the maintainer or open an [out-of-date package report] in
-> Nixpkgs.
+> The Waycorner package in Nixpkgs is not updated automatically by the project, and is instead
+> maintained by [@NotAShelf]. Please contact [@NotAShelf] or create an [out-of-date package report] on https://github.com/NixOS/nixpkgs in case the version is out-of-date.
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ cargo install waycorner --locked
 [`waycorner`]: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/misc/waycorner/default.nix
 [See installation instructions.]: https://search.nixos.org/packages?channel=unstable&show=waycorner&from=0&size=50&sort=relevance&type=packages&query=waycorner
 [@NotAShelf]: https://github.com/notashelf
-[out-of-date package report]: https://github.com/NixOS/nixpkgs/issues/new?assignees=&labels=9.needs%3A+package+%28update%29&projects=&template=out_of_date_package_report.md&title=Update+request%3A+PACKAGENAME+OLDVERSION+%E2%86%92+NEWVERSION
+[create an out-of-date package report]: https://github.com/NixOS/nixpkgs/issues/new?assignees=&labels=9.needs%3A+package+%28update%29&projects=&template=out_of_date_package_report.md&title=Update+request%3A+PACKAGENAME+OLDVERSION+%E2%86%92+NEWVERSION
+[NixOS/nixpkgs]: https://github.com/NixOS/nixpkgs
 
 The [`waycorner`] package is available via Nixpkgs. [See installation instructions.]
 
 > [!NOTE]
 > The Waycorner package in Nixpkgs is not updated automatically by the project, and is instead
-> maintained by [@NotAShelf]. Please contact [@NotAShelf] or create an [out-of-date package report] on https://github.com/NixOS/nixpkgs in case the version is out-of-date.
+> maintained by [@NotAShelf]. Please contact [@NotAShelf] or [create an out-of-date package report] on [NixOS/nixpkgs] in case the version is out-of-date.
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ timeout_ms = 250  # default
 
 # Hex color of the corner when previewed, supports transparency. (#AARRGGBB or #RRGGBB)
 # (Useful for debuging purposes when setting up several hot corners.)
-color = #FFFF0000  # default
+color = "#FFFF0000"  # default
 
 # Optional output config to specify what output to use.
 [left.output]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,34 @@ If you would like waycorner to be available on your distro's package manager, fe
 paru -S waycorner
 ```
 
+
+### Nix/NixOS
+
+There are several methods to install waycorner using Nix. Waycorner already exists in Nixpkgs, so it is a matter of preference or
+available tooling. You may pick whichever option suites your use case.
+
+#### Nix (Standalone)
+
+```bash
+nix profile install nixpkgs#waycorner
+```
+
+#### NixOS
+
+```nix
+{pkgs, ...}: {
+    environment.systemPackages = [pkgs.waycorner];
+}
+```
+
+#### Home-Manager
+
+```nix
+{pkgs, ...}: {
+    home.packages = [pkgs.waycorner];
+}
+```
+
 ### Cargo (crates.io)
 
 ```zsh

--- a/README.md
+++ b/README.md
@@ -16,39 +16,26 @@ If you would like waycorner to be available on your distro's package manager, fe
 paru -S waycorner
 ```
 
-
-### Nix/NixOS
-
-There are several methods to install waycorner using Nix. Waycorner already exists in Nixpkgs, so it is a matter of preference or
-available tooling. You may pick whichever option suites your use case.
-
-#### Nix (Standalone)
-
-```bash
-nix profile install nixpkgs#waycorner
-```
-
-#### NixOS
-
-```nix
-{pkgs, ...}: {
-    environment.systemPackages = [pkgs.waycorner];
-}
-```
-
-#### Home-Manager
-
-```nix
-{pkgs, ...}: {
-    home.packages = [pkgs.waycorner];
-}
-```
-
 ### Cargo (crates.io)
 
 ```zsh
 cargo install waycorner --locked
 ```
+
+### Nix/NixOS
+
+[`waycorner` package]: https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/applications/misc/waycorner/default.nix
+[search.nixos.org]: https://search.nixos.org/packages?channel=unstable&show=waycorner&from=0&size=50&sort=relevance&type=packages&query=waycorner
+[@NotAShelf]: https://github.com/notashelf
+[out-of-date package report]: https://github.com/NixOS/nixpkgs/issues/new?assignees=&labels=9.needs%3A+package+%28update%29&projects=&template=out_of_date_package_report.md&title=Update+request%3A+PACKAGENAME+OLDVERSION+%E2%86%92+NEWVERSION
+
+There is a [waycorner package] package available via Nixpkgs. Refer to [search.nixos.org] page for Waycorner
+for the appropriate installation methods.
+
+> [!NOTE]
+> The Waycorner package in Nixpkgs is not updated automatically by the project author, and is instead
+> maintained by [@NotAShelf]. Please contact the maintainer or open an [out-of-date package report] in
+> Nixpkgs.
 
 ### Manually
 
@@ -92,7 +79,7 @@ margin = 20  # default
 timeout_ms = 250  # default
 
 # Hex color of the corner when previewed, supports transparency. (#AARRGGBB or #RRGGBB)
-# (Useful for debuging purposes when setting up several hot corners.)
+# (Useful for debugging purposes when setting up several hot corners.)
 color = "#FFFF0000"  # default
 
 # Optional output config to specify what output to use.


### PR DESCRIPTION
Two real quick, really minor improvements to the documentation.

1. Waycorner is in Nixpkgs now (and has been for a while, I packaged it last year) so we can tell the users how to get it if they are using Nix
2. Fixes a minor issue with the example config, where `color = #FFFF0000` would cause an error.